### PR TITLE
fix translation bug

### DIFF
--- a/src/irmsd/_fortran/crest_mods/irmsd_module.f90
+++ b/src/irmsd/_fortran/crest_mods/irmsd_module.f90
@@ -319,14 +319,14 @@ contains  !> MODULE PROCEDURES START HERE
       y_norm = 0.0_wp
       rnat = 1.0_wp/real(nat,wp)
       do i = 1,3
-        xi(:nat) = x(i,:nat)
-        yi(:nat) = y(i,:nat)
+        xi(:nat) = x(i,1:nat)
+        yi(:nat) = y(i,1:nat)
         x_center(i) = sum(xi(1:nat))*rnat
         y_center(i) = sum(yi(1:nat))*rnat
-        xi(:nat) = xi(:nat)-x_center(i)
-        yi(:nat) = yi(:nat)-y_center(i)
-        x(i,:nat) = xi(:nat)
-        y(i,:nat) = yi(:nat)
+        xi(1:nat) = xi(1:nat)-x_center(i)
+        yi(1:nat) = yi(1:nat)-y_center(i)
+        x(i,1:nat) = xi(1:nat)
+        y(i,1:nat) = yi(1:nat)
         x_norm = x_norm+dot_product(xi,xi)
         y_norm = y_norm+dot_product(yi,yi)
       end do
@@ -334,7 +334,7 @@ contains  !> MODULE PROCEDURES START HERE
       !> calculate the R matrix
       do i = 1,3
         do j = 1,3
-          Rmatrix(i,j) = dot_product(x(i,:nat),y(j,:nat))
+          Rmatrix(i,j) = dot_product(x(i,1:nat),y(j,1:nat))
         end do
       end do
 


### PR DESCRIPTION
I found a bug in the `rmsd_core` subroutine when used with a mask. Leading to wrong `rmsdval` and `U` matrices. I think it is somehow related to the `cache` handling as the cached vectors stay longer than their masked counterparts should be.

It is most obvious when translating a molecules by a large quantity.
Small Example:
```text
[ethane.xyz]
8
XYZ file generated by Avogadro.
C     -3.8195626736    1.7934494019    0.0000000000
C     -3.4969640010    2.5577809275   -0.6757422050
H     -3.0195661977    1.5450768650    0.6657453221
H     -4.1048536496    0.9241046133   -0.5547511243
H     -4.6568668459    2.1468352017    0.5647480072
H     -2.6596598286    2.2043951276   -1.2404902122
H     -4.2969604768    2.8061534644   -1.3414875271
H     -3.2116730249    3.4271257160   -0.1209910808
```

The same molecule translated by 10A:
```text
ethane-translated.xyz 
8
XYZ from PySCF
C           6.18044       11.79345       10.00000
C           6.50304       12.55778        9.32426
H           6.98043       11.54508       10.66575
H           5.89515       10.92410        9.44525
H           5.34313       12.14684       10.56475
H           7.34034       12.20440        8.75951
H           5.70304       12.80615        8.65851
H           6.78833       13.42713        9.87901
```

## Prior to this fix:
output without using heavy mask:
```bash
irmsd --rmsd ethane.xyz ethane-translated.xyz
Cartesian RMSD: 0.0000042953 Å
U matrix (Fortran order)
[[ 1.        0.000001  0.000002]
 [-0.000001  1.       -0.000002]
 [-0.000002  0.000002  1.      ]]

Aligned structure:
8

C      6.180470    11.793426    10.000009
C      6.503070    12.557757     9.324270
H      6.980461    11.545054    10.665758
H      5.895178    10.924077     9.445258
H      5.343162    12.146816    10.564762
H      7.340369    12.204377     8.759518
H      5.703069    12.806129     8.658522
H      6.788362    13.427106     9.879021
```
output using heavy mask
```bash
irmsd --rmsd --heavy ethane.xyz ethane-translated.xyz 
Cartesian RMSD: 21.6815444684 Å
U matrix (Fortran order)
[[ 0.010121 -0.498733 -0.866697]
 [ 0.842078  0.471675 -0.261587]
 [ 0.539261 -0.727179  0.424745]]

Aligned structure:
8

C    -14.486193     8.151212    -0.995617
C    -14.278463     8.960146    -1.664473
H    -14.931230     8.533564    -0.100830
H    -13.574708     7.646040    -0.752918
H    -15.160382     7.465085    -1.464249
H    -13.604279     9.646269    -1.195855
H    -13.833426     8.577786    -2.559266
H    -15.189949     9.465318    -1.907173
```

## After the proposed fix
```bash
irmsd --rmsd --heavy ethane.xyz ethane-translated.xyz 
Cartesian RMSD: 0.0000010412 Å
U matrix (Fortran order)
[[ 1.       -0.000001  0.000001]
 [ 0.000001  1.        0.000001]
 [-0.000001 -0.000001  1.      ]]

Aligned structure:
8

C      6.180439    11.793464     9.999985
C      6.503037    12.557794     9.324244
H      6.980430    11.545095    10.665734
H      5.895149    10.924113     9.445235
H      5.343129    12.146853    10.564736
H      7.340336    12.204415     8.759493
H      5.703035    12.806162     8.658495
H      6.788326    13.427145     9.878993
```

__Not quite sure whether this is the best way to fix it__