### PR TITLE
fix canonical from connectivity

### DIFF
--- a/src/irmsd/_fortran/crest_mods/canonical.f90
+++ b/src/irmsd/_fortran/crest_mods/canonical.f90
@@ -169,12 +169,12 @@ contains  !> MODULE PROCEDURES START HERE
 !>--- determine number of subgraphs via CN
       call mol%cn_to_bond(cn,Bmat,'cov')
       call wbo2adjacency(nodes,Bmat,Amat,0.02_wp)
-      deallocate (Bmat)
+      deallocate (Bmat,cn)
     end if
     allocate (frag(nodes),source=0)
     call setup_fragments(nodes,Amat,frag)
     self%nfrag = maxval(frag(:),1)
-    deallocate (frag,cn)
+    deallocate (frag)
 
 !>--- documment neighbour list
     maxnei = 0
@@ -322,6 +322,7 @@ contains  !> MODULE PROCEDURES START HERE
     nat = size(at,1)
     allocate(tmpmol%at(nat))
     tmpmol%at(:) = at(:)
+    tmpmol%nat = nat
 
     call self%init(tmpmol,wbo=wbo,invtype=invtype,heavy=heavy)
 end subroutine init_canonical_sorter_connect

--- a/src/irmsd/api/canonical_exposed.py
+++ b/src/irmsd/api/canonical_exposed.py
@@ -63,45 +63,45 @@ def get_canonical_fortran(
     return rank
 
 
-def get_canonical_from_connect_fortran(                                                                              
-    atom_numbers: np.ndarray,                                                                           
-    connectivity: np.ndarray,                                                                      
-    heavy: bool = False,                                                                                
-) -> np.ndarray:                                                                                        
-    """                                                                                                 
-    Core API: call the Fortran routine to calculate CN                                                  
-                                                                                                        
-    Parameters                                                                                          
-    ----------                                                                                          
-    atom_numbers : (N,) int32-like                                                                      
-        Atomic numbers (or types).                                                                      
-    connectivity : (N, N) int32-like                                                                     
-        Connectivity matrix 
-    heavy : bool, optional                                                                              
-        Whether to consider only heavy atoms (default: False).                                          
-                                                                                                        
-    Returns                                                                                             
-    -------                                                                                             
-    rank : (N,) int32                                                                                   
-        Rank array.                                                                                     
-    """                                                                                                 
-    atom_numbers = np.ascontiguousarray(atom_numbers, dtype=np.int32)                                   
-    connect = np.ascontiguousarray(connectivity, dtype=np.float64)                                             
-            
+def get_canonical_from_connect_fortran(
+    atom_numbers: np.ndarray,
+    connectivity: np.ndarray,
+    heavy: bool = False,
+) -> np.ndarray:
+    """
+    Core API: call the Fortran routine to calculate CN
+
+    Parameters
+    ----------
+    atom_numbers : (N,) int32-like
+        Atomic numbers (or types).
+    connectivity : (N, N) int32-like
+        Connectivity matrix
+    heavy : bool, optional
+        Whether to consider only heavy atoms (default: False).
+
+    Returns
+    -------
+    rank : (N,) int32
+        Rank array.
+    """
+    atom_numbers = np.ascontiguousarray(atom_numbers, dtype=np.int32)
+    connect = np.ascontiguousarray(connectivity, dtype=np.int32)
+
     n = int(connect.shape[0])
-    if connect.ndim != 2 or connect.shape[1] != n: 
-        raise ValueError("Connectivity must have shape (N, N)")                                            
-                                                                                                        
-    connect_flat = connect.reshape(-1).copy(order="F")                                                       
-                                                                                                        
-    rank = np.ascontiguousarray(np.zeros(n), dtype=np.int32)                                            
-                                                                                                        
-    _F.get_canonical_sorter_fortran_raw(                                                                
-        n,                                                                                              
-        atom_numbers,                                                                                   
-        connect_flat,                                                                                    
-        rank,                                                                                           
-        heavy=heavy,                                                                                    
-    )                                                                                                   
-                                                                                                        
-    return rank                                                                                         
+    if connect.ndim != 2 or connect.shape[1] != n:
+        raise ValueError("Connectivity must have shape (N, N)")
+
+    connect_flat = connect.reshape(-1).copy(order="F")
+
+    rank = np.ascontiguousarray(np.zeros(n), dtype=np.int32)
+
+    _F.get_ids_from_connect_fortran_raw(
+        n,
+        atom_numbers,
+        connect_flat,
+        rank,
+        heavy=heavy,
+    )
+
+    return rank

--- a/src/irmsd/bindings/canonical_exposed.py
+++ b/src/irmsd/bindings/canonical_exposed.py
@@ -91,60 +91,60 @@ def get_canonical_sorter_fortran_raw(
     )
 
 
-# We expose the canonical function as:                                                                  
-#   get_ids_from_connect_fortran(natoms: c_int,                                                 
-#                  types: int32[C_CONTIGUOUS](natoms),                                                  
-#                  connectivity_flat: int32[F_CONTIGUOUS](natoms,natoms) or None,                                   
-#                  heavy: boolean                                                                       
+# We expose the canonical function as:
+#   get_ids_from_connect_fortran(natoms: c_int,
+#                  types: int32[C_CONTIGUOUS](natoms),
+#                  connectivity_flat: int32[F_CONTIGUOUS](natoms,natoms) or None,
+#                  heavy: boolean
 #                  rank: int32[C_CONTIGUOUS](natoms)
-LIB.get_ids_from_connect_fortran.argtypes = [                                                           
-    ct.c_int,                                                                                           
-    ndpointer(dtype=np.int32, flags="C_CONTIGUOUS"),                                                    
-    ndpointer(dtype=np.int32, flags="F_CONTIGUOUS"),                                                  
-    ct.c_bool,                                                                                          
-    ndpointer(dtype=np.int32, flags="C_CONTIGUOUS"),                                                    
-]                                                                                                       
-LIB.get_ids_from_connect_fortran.restype = None                                                         
-                                                                                                        
-                                                                                                        
-def get_ids_from_connect_fortran_raw(                                                                   
-    natoms: int,                                                                                        
-    types: np.ndarray,                                                                                  
-    connectivity_flat: np.ndarray,                                                                            
-    rank: np.ndarray,                                                                                   
-    heavy: bool = False,                                                                                
-) -> None:                                                                                              
+LIB.get_ids_from_connect_fortran.argtypes = [
+    ct.c_int,
+    ndpointer(dtype=np.int32, flags="C_CONTIGUOUS"),
+    ndpointer(dtype=np.int32, flags="F_CONTIGUOUS"),
+    ct.c_bool,
+    ndpointer(dtype=np.int32, flags="C_CONTIGUOUS"),
+]
+LIB.get_ids_from_connect_fortran.restype = None
+
+
+def get_ids_from_connect_fortran_raw(
+    natoms: int,
+    types: np.ndarray,
+    connectivity_flat: np.ndarray,
+    rank: np.ndarray,
+    heavy: bool = False,
+) -> None:
     """Low-level call that matches the Fortran signature exactly.
-                                                                                                        
-    Parameters                                                                                          
-    ----------                                                                                          
-    natoms : int                                                                                        
-        Number of atoms (must be consistent with array lengths).                                        
-    types : (natoms,) int32, C-contiguous                                                               
-        Atomic numbers (or type IDs).                                                                   
-    connectivity_flat : (natoms*natoms,) int32, F-contiguous                                                     
+
+    Parameters
+    ----------
+    natoms : int
+        Number of atoms (must be consistent with array lengths).
+    types : (natoms,) int32, C-contiguous
+        Atomic numbers (or type IDs).
+    connectivity_flat : (natoms*natoms,) int32, F-contiguous
         indicates whether a bond between two atoms exists
-    rank : (natoms,) int32, C-contiguous                                                                
-        Output array for rank.                                                                          
-    heavy : bool, optional                                                                              
-        Whether to consider only heavy atoms (default: False).                                          
-    """                                                                                                 
-    # light validation to catch mismatches early                                                        
-    if types.dtype != np.int32 or not types.flags.c_contiguous:                                         
-        raise TypeError("types must be int32 and C-contiguous")                                         
-    if connectivity_flat.dtype != np.int32 or not connectivity_flat.flags.f_contiguous:                           
-        raise TypeError("connectivity_flat must be int32 and F-contiguous")                                 
-    if connectivity_flat.size != natoms * natoms:                                                                  
-        raise ValueError("connectivity_flat length must be natoms*natoms")                                         
-    if types.size != natoms:                                                                            
-        raise ValueError("types length must be natoms")                                                 
-    if rank.dtype != np.int32 or not rank.flags.c_contiguous or rank.size != natoms:                    
-        raise TypeError("rank must be int32, C-contiguous, size natoms")                                
-                                                                                                        
-    LIB.get_ids_from_connect_fortran_fortran(                                                                   
-        int(natoms),                                                                                    
-        types,                                                                                          
-        connectivity_flat,                                                                                    
-        bool(heavy),                                                                                    
-        rank,                                                                                           
-    )                                                                                                   
+    rank : (natoms,) int32, C-contiguous
+        Output array for rank.
+    heavy : bool, optional
+        Whether to consider only heavy atoms (default: False).
+    """
+    # light validation to catch mismatches early
+    if types.dtype != np.int32 or not types.flags.c_contiguous:
+        raise TypeError("types must be int32 and C-contiguous")
+    if connectivity_flat.dtype != np.int32 or not connectivity_flat.flags.f_contiguous:
+        raise TypeError("connectivity_flat must be int32 and F-contiguous")
+    if connectivity_flat.size != natoms * natoms:
+        raise ValueError("connectivity_flat length must be natoms*natoms")
+    if types.size != natoms:
+        raise ValueError("types length must be natoms")
+    if rank.dtype != np.int32 or not rank.flags.c_contiguous or rank.size != natoms:
+        raise TypeError("rank must be int32, C-contiguous, size natoms")
+
+    LIB.get_ids_from_connect_fortran(
+        int(natoms),
+        types,
+        connectivity_flat,
+        bool(heavy),
+        rank,
+    )


### PR DESCRIPTION
I think there is a (few) little bugs in the `canonical_from_connect` pipeline.
A small test file:
```python
import numpy as np

from irmsd.api.canonical_exposed import (
    get_canonical_fortran,
    get_canonical_from_connect_fortran,
)

atom_numbers_caffeine = np.asarray(
    [6, 7, 6, 7, 6, 6, 6, 8, 7, 6, 8, 7, 6, 6, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
    dtype=np.int32,
)
connectivity_caffeine = np.asarray(
    [
        [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
        [1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0],
        [0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
    ],
    # fmt: on
    dtype=np.int32,
)

# methane
atom_numbers_methane = np.asarray([6, 1, 1, 1, 1], dtype=np.int32)
connectivity_methane = np.asarray(
    [
        [0, 1, 1, 1, 1],
        [1, 0, 0, 0, 0],
        [1, 0, 0, 0, 0],
        [1, 0, 0, 0, 0],
        [1, 0, 0, 0, 0],
    ],
    dtype=np.int32,
)

atom_numbers = atom_numbers_methane
connectivity = connectivity_methane

atom_numbers = atom_numbers_caffeine
connectivity = connectivity_caffeine

canonical_atom_id = get_canonical_from_connect_fortran(
    atom_numbers,
    connectivity,
    heavy=False,
)
print("Canonical atom IDs from connectivity:")
print(canonical_atom_id)
```

without the changes it fails for me. Starting with a wrong `dtype` but continuing down into the fortran layer