### PR TITLE
Fix `rthr` default value

### DIFF
--- a/src/irmsd/interfaces/ase_io.py
+++ b/src/irmsd/interfaces/ase_io.py
@@ -503,7 +503,7 @@ def get_irmsd_ase(
 
 def sorter_irmsd_ase(
     atoms_list: Sequence["ase.Atoms"],
-    rthr: float,
+    rthr: float = 0.125,  # aligned with '--rthr' in src/irmsd/cli.py
     iinversion: int = 0,
     allcanon: bool = True,
     printlvl: int = 0,

--- a/src/irmsd/interfaces/mol_interface.py
+++ b/src/irmsd/interfaces/mol_interface.py
@@ -230,10 +230,10 @@ def get_irmsd_molecule(
 
 def sorter_irmsd_molecule(
     molecule_list: Sequence[Molecule],
-    rthr: float,
     iinversion: int = 0,
     allcanon: bool = True,
     printlvl: int = 0,
+    rthr: float = 0.125,  # aligned with '--rthr' in src/irmsd/cli.py
     ethr: float | None = None,
     ewin: float | None = None,
 ) -> Tuple[np.ndarray, List[Molecule]]:

--- a/src/irmsd/interfaces/mol_interface.py
+++ b/src/irmsd/interfaces/mol_interface.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, List
 
 import numpy as np
 
@@ -230,10 +230,10 @@ def get_irmsd_molecule(
 
 def sorter_irmsd_molecule(
     molecule_list: Sequence[Molecule],
+    rthr: float = 0.125,  # aligned with '--rthr' in src/irmsd/cli.py
     iinversion: int = 0,
     allcanon: bool = True,
     printlvl: int = 0,
-    rthr: float = 0.125,  # aligned with '--rthr' in src/irmsd/cli.py
     ethr: float | None = None,
     ewin: float | None = None,
 ) -> Tuple[np.ndarray, List[Molecule]]:

--- a/src/irmsd/interfaces/rdkit_io.py
+++ b/src/irmsd/interfaces/rdkit_io.py
@@ -463,7 +463,7 @@ def get_irmsd_rdkit(
 
 def sorter_irmsd_rdkit(
     molecules: "Mol" | Sequence["Mol"],
-    rthr: float,
+    rthr: float = 0.125,  # aligned with '--rthr' in src/irmsd/cli.py
     iinversion: int = 0,
     allcanon: bool = True,
     printlvl: int = 0,


### PR DESCRIPTION
Take over default value from `cli.py` in `--rthr` to make example in `README.md` working.